### PR TITLE
change float64 to float32

### DIFF
--- a/compute-accuracy/main.go
+++ b/compute-accuracy/main.go
@@ -58,8 +58,10 @@ func main() {
 	for b = 0; b < words; b++ {
 		vocab[b], err = br.ReadString(' ')
 		vocab[b] = strings.ToUpper(strings.Replace(vocab[b], "\n", "", -1))
-		err = binary.Read(br, binary.LittleEndian, M[b*size:b*size+size])
-		failOnError(err, "Cannot read input file")
+		for i := b * size; i < b*size+size; i++ {
+			err = binary.Read(br, binary.LittleEndian, float32(M[i]))
+			failOnError(err, "Cannot read input file")
+		}
 		length = 0
 		for a = 0; a < size; a++ {
 			length += M[a+b*size] * M[a+b*size]

--- a/distance/main.go
+++ b/distance/main.go
@@ -46,8 +46,10 @@ func main() {
 		vocab[b], err = br.ReadString(' ')
 		vocab[b] = vocab[b][:len(vocab[b])-1]
 		vocab[b] = strings.Replace(vocab[b], "\n", "", -1)
-		err = binary.Read(br, binary.LittleEndian, M[b*size:b*size+size])
-		failOnError(err, "Cannot read input file")
+		for i := b * size; i < b*size+size; i++ {
+			err = binary.Read(br, binary.LittleEndian, float32(M[i]))
+			failOnError(err, "Cannot read input file")
+		}
 		length = 0
 		for a = 0; a < size; a++ {
 			length += M[a+b*size] * M[a+b*size]

--- a/word-analogy/main.go
+++ b/word-analogy/main.go
@@ -46,8 +46,10 @@ func main() {
 		vocab[b], err = br.ReadString(' ')
 		vocab[b] = vocab[b][:len(vocab[b])-1]
 		vocab[b] = strings.Replace(vocab[b], "\n", "", -1)
-		err = binary.Read(br, binary.LittleEndian, M[b*size:b*size+size])
-		failOnError(err, "Cannot read input file")
+		for i := b * size; i < b*size+size; i++ {
+			err = binary.Read(br, binary.LittleEndian, float32(M[i]))
+			failOnError(err, "Cannot read input file")
+		}
 		length = 0
 		for a = 0; a < size; a++ {
 			length += M[a+b*size] * M[a+b*size]

--- a/word2vec/main.go
+++ b/word2vec/main.go
@@ -804,7 +804,9 @@ func TrainModel() {
 		for a := 0; a < vocab_size; a++ {
 			fmt.Fprintf(fo, "%s ", vocab[a].word)
 			if binaryf != 0 {
-				binary.Write(fo, binary.LittleEndian, syn0[a*layer1_size:(a+1)*layer1_size])
+				for i := a * layer1_size; i < (a+1)*layer1_size; i++ {
+					binary.Write(fo, binary.LittleEndian, float32(syn0[i]))
+				}
 			} else {
 				for b := 0; b < layer1_size; b++ {
 					fmt.Fprintf(fo, "%f ", syn0[a*layer1_size+b])


### PR DESCRIPTION
original word2vec use float (4byte: not float64) for values in binary file. So it should use float32 instead.